### PR TITLE
Add issue linking

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -51,5 +51,6 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_JSCPD: false
+          VALIDATE_PYTHON_ISORT: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,6 @@ verbose_test:
 wheel: clean format
 	poetry build
 
-venv:
-	virtualenv venv
-
 local: wheel
 	docker buildx build --load -t unixorn/jira-commands .
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Some command-line tools for interacting with JIRA.
 - jc-ticket-comment-on-ticket
 - jc-ticket-create
 - jc-ticket-examine
+- jc-ticket-link
 - jc-ticket-print
 - jc-ticket-transition-list
 - jc-ticket-transition-set

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Some command-line tools for interacting with JIRA.
 
 - jc
+- jc-get-link-types
 - jc-ticket-assign
 - jc-ticket-close
 - jc-ticket-comment

--- a/jira_commands/cli/crudops.py
+++ b/jira_commands/cli/crudops.py
@@ -236,6 +236,33 @@ def createTicket():
     return results
 
 
+def getLinkTypes():
+    """
+    Get all the link types on a server
+    """
+    parser = baseCLIParser()
+    parser.add_argument("--json", help="Output in JSON format", action="store_true")
+    cli = parser.parse_args()
+
+    loglevel = getattr(logging, cli.log_level.upper(), None)
+    logFormat = "[%(asctime)s][%(levelname)8s][%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
+    logging.basicConfig(level=loglevel, format=logFormat)
+    logging.info("Set log level to %s", cli.log_level.upper())
+
+    settings = loadJiraSettings(path=cli.settings_file, cli=cli)
+
+    jira = JiraTool(settings=settings)
+
+    link_type_names = []
+    for link_type in jira.connection.issue_link_types():
+        logging.debug(link_type.name)
+        link_type_names.append(link_type.name)
+    if cli.json:
+        print(json.dumps({"link_types": link_type_names}, indent=2))
+    else:
+        print(f"Link type names: {link_type_names}")
+
+
 def linkTickets():
     """
     Link two tickets

--- a/jira_commands/cli/crudops.py
+++ b/jira_commands/cli/crudops.py
@@ -6,10 +6,11 @@
 # License: Apache 2.0
 # Copyright 2022, ZScaler Inc.
 
+import json
 import logging
 import sys
 
-from jira_commands.cli.common import parseTicketCLI, ticketCreationParser
+from jira_commands.cli.common import baseCLIParser, parseTicketCLI, ticketCreationParser
 from jira_commands.jira import JiraTool, loadJiraSettings, makeIssueData
 
 
@@ -122,6 +123,39 @@ def parseGetTransitionsCLI():
     return cliArgs
 
 
+def parseTicketLinkCLI():
+    """
+    Command line options for linking two tickets
+    """
+    parser = parseTicketCLI(description="Link two JIRA tickets")
+    parser.add_argument(
+        "--target",
+        type=str,
+        required=True,
+        help="Target ticket",
+    )
+
+    link_types = [
+        "Blocks",
+        "Depends",
+        "Bugs" "Clones",
+    ]
+    parser.add_argument(
+        "--link-type",
+        type=str,
+        required=True,
+        help=f"Link type. Case matters. Consider {link_types} as options, "
+        "though your server may have other types too. 'jc get link types' "
+        "will show all the link types on your JIRA server",
+    )
+    cli = parser.parse_args()
+    loglevel = getattr(logging, cli.log_level.upper(), None)
+    logFormat = "[%(asctime)s][%(levelname)8s][%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
+    logging.basicConfig(level=loglevel, format=logFormat)
+    logging.info("Set log level to %s", cli.log_level.upper())
+    return cli
+
+
 def parseTransitionToCLI():
     """
     Parse the command line options for transition set tool
@@ -185,7 +219,7 @@ def closeTicket():
 
 def createTicket():
     """
-    Main program driver
+    Create a JIRA ticket
     """
     cli = parseCreateTicketCLI()
     logging.debug(f"cli: {cli}")
@@ -195,9 +229,28 @@ def createTicket():
 
     jira = JiraTool(settings=settings)
     if cli.issue_type == "Sub-task":
-        logging.info(jira.createSubtask(issue_data=issue_data, parent=cli.parent))
+        results = jira.createSubtask(issue_data=issue_data, parent=cli.parent)
     else:
-        logging.info(jira.createTicket(issue_data=issue_data, strict=False))
+        results = jira.createTicket(issue_data=issue_data, strict=False)
+    logging.info(results)
+    return results
+
+
+def linkTickets():
+    """
+    Link two tickets
+    """
+    cli = parseTicketLinkCLI()
+    logging.debug(f"cli: {cli}")
+
+    settings = loadJiraSettings(path=cli.settings_file, cli=cli)
+
+    jira = JiraTool(settings=settings)
+    results = jira.linkIssues(
+        source=cli.ticket, target=cli.target, link_type=cli.link_type
+    )
+    logging.info(results)
+    print(results)
 
 
 def getTransitions():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira-commands"
-version = "0.2.1"
+version = "0.3.0"
 description = "Command line utilities for interacting with JIRA"
 authors = ["Joe Block <jblock@zscaler.com>"]
 homepage = "https://github.com/unixorn/jira-commands"
@@ -21,12 +21,14 @@ flake8 = "^4.0.1"
 
 [tool.poetry.scripts]
 jc = 'jira_commands.cli.jc:jc_driver'
+jc-link-tickets = 'jira_commands.cli.crudops:linkTickets'
 jc-ticket-assign = 'jira_commands.cli.crudops:assignTicket'
 jc-ticket-close = 'jira_commands.cli.crudops:closeTicket'
 jc-ticket-comment = 'jira_commands.cli.crudops:commentOnTicket'
 jc-ticket-comment-on-ticket = 'jira_commands.cli.crudops:commentOnTicket'
 jc-ticket-create = 'jira_commands.cli.crudops:createTicket'
 jc-ticket-examine = 'jira_commands.cli.vivisect:vivisect'
+jc-ticket-link = 'jira_commands.cli.crudops:linkTickets'
 jc-ticket-print = 'jira_commands.cli.print:printTicket'
 jc-ticket-transition-list = 'jira_commands.cli.crudops:getTransitions'
 jc-ticket-transition-set = 'jira_commands.cli.crudops:transitionTo'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ flake8 = "^4.0.1"
 
 [tool.poetry.scripts]
 jc = 'jira_commands.cli.jc:jc_driver'
+jc-get-link-types = 'jira_commands.cli.crudops:getLinkTypes'
 jc-link-tickets = 'jira_commands.cli.crudops:linkTickets'
 jc-ticket-assign = 'jira_commands.cli.crudops:assignTicket'
 jc-ticket-close = 'jira_commands.cli.crudops:closeTicket'


### PR DESCRIPTION
- Add code to link issues. 
The `JIRA.create_issue_link` function from the upstream jira module fails (see https://github.com/pycontribs/jira/issues/1296 for details)  so we had to write a workaround using `requests.put()`.

- Add `jc-ticket-link` and `jc-get-link-types` helper scripts.
- Bump version to `0.3.0`