### PR TITLE
Fix some cli argument handling bugs

### DIFF
--- a/jira_commands/cli/common.py
+++ b/jira_commands/cli/common.py
@@ -101,20 +101,28 @@ def base_cli_parser(description: str = None):
 
 
 def parseTicketCLI(description: str):
+    return parse_ticket_cli(description=description)
+
+
+def parse_ticket_cli(description: str = None):
     """
     Parse the command line options and return the ticket id
     """
-    parser = baseCLIParser(description=description)
+    parser = base_cli_parser(description=description)
 
     parser.add_argument("--ticket", "-t", type=str, required=True)
     return parser
 
 
 def ticketCreationParser(description: str):
+    return ticket_creation_parser(description=description)
+
+
+def ticket_creation_parser(description: str = None):
     """
     Create the base ticket creation parser
     """
-    parser = baseCLIParser(description="Create a JIRA ticket")
+    parser = base_cli_parser(description="Create a JIRA ticket")
 
     # Collect issue attributes
     parser.add_argument("--description", help="Ticket description", type=str)

--- a/jira_commands/cli/common.py
+++ b/jira_commands/cli/common.py
@@ -11,6 +11,10 @@ from thelogrus.fileops import readableFile
 
 
 def baseCLIParser(description: str = None):
+    return base_cli_parser(description=description)
+
+
+def base_cli_parser(description: str = None):
     """
     Create the base argument parser that we build on for individual scripts
 
@@ -128,7 +132,7 @@ def ticketCreationParser(description: str):
     )
     parser.add_argument(
         "--priority",
-        help="Set priority for the new ticket. Use 'jc get priorites' to find a list of available ticket priorities.",
+        help="Set priority for the new ticket. Use 'jc get priorities' to find a list of available ticket priorities.",
         type=str,
     )
     parser.add_argument(

--- a/jira_commands/cli/crudops.py
+++ b/jira_commands/cli/crudops.py
@@ -9,7 +9,11 @@ import json
 import logging
 import sys
 
-from jira_commands.cli.common import baseCLIParser, parseTicketCLI, ticketCreationParser
+from jira_commands.cli.common import (
+    base_cli_parser,
+    parse_ticket_cli,
+    ticket_creation_parser,
+)
 from jira_commands.jira import JiraTool, load_jira_settings, make_issue_data
 
 
@@ -21,7 +25,7 @@ def parseTicketAssignCLI():
     Returns:
         An argparse CLI object
     """
-    parser = parseTicketCLI(description="Assign a JIRA ticket to someone")
+    parser = parse_ticket_cli(description="Assign a JIRA ticket to someone")
     parser.add_argument(
         "--assignee",
         type=str,
@@ -44,7 +48,7 @@ def parseTicketCommentCLI(description: str = "Comment on a JIRA ticket"):
     Returns:
         An argparse CLI object
     """
-    parser = parseTicketCLI(description=description)
+    parser = parse_ticket_cli(description=description)
     parser.add_argument(
         "--comment",
         type=str,
@@ -67,7 +71,7 @@ def parseTicketCloseCLI(description="Close a JIRA ticket"):
     Returns:
         An argparse CLI object
     """
-    parser = parseTicketCLI(description=description)
+    parser = parse_ticket_cli(description=description)
     parser.add_argument(
         "--comment",
         type=str,
@@ -92,7 +96,7 @@ def parseTicketInspectionCLI(
     Returns:
         An argparse CLI object
     """
-    parser = parseTicketCLI(description=description)
+    parser = parse_ticket_cli(description=description)
     cli = parser.parse_args()
     loglevel = getattr(logging, cli.log_level.upper(), None)
     logFormat = "[%(asctime)s][%(levelname)8s][%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
@@ -105,7 +109,7 @@ def parseCreateTicketCLI(description: str = "Create a JIRA ticket"):
     """
     Parse the command line options
     """
-    parser = ticketCreationParser(description=description)
+    parser = ticket_creation_parser(description=description)
     cli = parser.parse_args()
 
     loglevel = getattr(logging, cli.log_level.upper(), None)
@@ -129,7 +133,7 @@ def parseGetTransitionsCLI(
     """
     Parse the command line options for transition list tool
     """
-    parser = parseTicketCLI(description=description)
+    parser = parse_ticket_cli(description=description)
 
     cli = parser.parse_args()
     loglevel = getattr(logging, cli.log_level.upper(), None)
@@ -143,7 +147,7 @@ def parseTicketLinkCLI(description: str = "Link two JIRA tickets"):
     """
     Command line options for linking two tickets
     """
-    parser = parseTicketCLI(description=description)
+    parser = parse_ticket_cli(description=description)
     parser.add_argument(
         "--target",
         type=str,
@@ -178,7 +182,7 @@ def parseTransitionToCLI(
     """
     Parse the command line options for transition set tool
     """
-    parser = parseTicketCLI(description=description)
+    parser = parse_ticket_cli(description=description)
     parser.add_argument(
         "--transition-to", help="Transition a ticket to a named state", type=str
     )
@@ -258,7 +262,7 @@ def getLinkTypes():
     """
     Get all the link types on a server
     """
-    parser = baseCLIParser()
+    parser = base_cli_parser()
     parser.add_argument("--json", help="Output in JSON format", action="store_true")
     cli = parser.parse_args()
 
@@ -308,7 +312,7 @@ def getPriorities():
     """
     Get all the priorities on a server
     """
-    parser = baseCLIParser(
+    parser = base_cli_parser(
         description="Get list of priorities on a server and their IDs"
     )
     parser.add_argument("--json", help="Output in JSON format", action="store_true")

--- a/jira_commands/cli/list.py
+++ b/jira_commands/cli/list.py
@@ -7,7 +7,7 @@
 
 import logging
 
-from jira_commands.cli.common import baseCLIParser
+from jira_commands.cli.common import base_cli_parser
 from jira_commands.jira import JiraTool, load_jira_settings
 
 
@@ -16,7 +16,7 @@ def parseListCLI(description="List JIRA tickets in a project"):
     Parse the command line options for the ticket list script and
     initialize logging.
     """
-    parser = baseCLIParser(description=description)
+    parser = base_cli_parser(description=description)
     parser.add_argument("--project", "-p", type=str, default="SYSENG")
 
     cli = parser.parse_args()

--- a/jira_commands/cli/map_extractor.py
+++ b/jira_commands/cli/map_extractor.py
@@ -16,7 +16,7 @@ import re
 
 from thelogrus.yaml import writeYamlFile
 
-from jira_commands.cli.common import baseCLIParser
+from jira_commands.cli.common import base_cli_parser
 from jira_commands.jira import JiraTool, load_jira_settings
 
 
@@ -29,7 +29,7 @@ def mappings_extractor_parser(
     Args:
         description: What description we want printed by --help
     """
-    parser = baseCLIParser(description=description)
+    parser = base_cli_parser(description=description)
     parser.add_argument(
         "--mapping-output-file",
         help="Where to write the extracted JIRA field mappings",

--- a/jira_commands/cli/vivisect.py
+++ b/jira_commands/cli/vivisect.py
@@ -10,7 +10,7 @@ import json
 import logging
 import pprint
 
-from jira_commands.cli.common import parseTicketCLI, baseCLIParser
+from jira_commands.cli.common import base_cli_parser, parse_ticket_cli
 from jira_commands.jira import JiraTool, load_jira_settings
 
 
@@ -32,7 +32,7 @@ def parse_dump_all_customfields_cli():
     """
     Parse the command line options for jc-ticket-dump-all-customfields
     """
-    parser = parseTicketCLI(description="Dump a ticket's metadata")
+    parser = parse_ticket_cli(description="Dump a ticket's metadata")
 
     cliArgs = parser.parse_args()
     loglevel = getattr(logging, cliArgs.log_level.upper(), None)
@@ -57,7 +57,7 @@ def dump_metadata():
 
 
 def extract_allowed_values():
-    cli = parseTicketFieldCLI(
+    cli = parse_ticket_field_cli(
         description="Get the allowed values for custom field on a ticket. "
         " Jira's API requires it be read from a ticket, not an issue type."
     ).parse_args()
@@ -87,7 +87,7 @@ def parse_metadata_cli():
     """
     Parse the command line options for jc-ticket-metadata
     """
-    parser = parseTicketCLI(description="Dump a ticket's metadata")
+    parser = parse_ticket_cli(description="Dump a ticket's metadata")
 
     cliArgs = parser.parse_args()
     loglevel = getattr(logging, cliArgs.log_level.upper(), None)
@@ -98,10 +98,17 @@ def parse_metadata_cli():
 
 
 def parseVivisectCLI():
+    logging.warning(
+        "parseVivisectCLI is deprecated and will be removed soon. Use parse_vivisect_cli instead"
+    )
+    return parse_vivisect_cli()
+
+
+def parse_vivisect_cli():
     """
     Parse the command line options
     """
-    parser = parseTicketCLI(
+    parser = parse_ticket_cli(
         description="Vivisect a JIRA ticket so we can determine which custom fields map to which data keys"
     )
 
@@ -118,7 +125,7 @@ def vivisect():
     Vivisect a ticket so we can figure out what key names the various custom
     fields have, what transitions are available, etc.
     """
-    cli = parseVivisectCLI()
+    cli = parse_vivisect_cli()
     logging.debug(f"cli: {cli}")
 
     settings = load_jira_settings(path=cli.settings_file, cli=cli)
@@ -128,10 +135,17 @@ def vivisect():
 
 
 def parseTicketFieldCLI(description: str):
+    logging.warning(
+        "parseTicketFieldCLI is deprecated and will be removed, use parse_ticket_field_cli instead"
+    )
+    return parse_ticket_field_cli(description=description)
+
+
+def parse_ticket_field_cli(description: str):
     """
     Parse the command line options and return the ticket id
     """
-    parser = baseCLIParser(description=description)
+    parser = base_cli_parser(description=description)
 
     parser.add_argument("--ticket", "-t", type=str, required=True)
     parser.add_argument("--custom-field", "-c", type=str, required=True)
@@ -145,7 +159,7 @@ def listAllowedFieldValues():
     JIRA won't let us do this by issue type because that would be too logical,
     we have to examine a ticket instead.
     """
-    cli = parseTicketFieldCLI(
+    cli = parse_ticket_field_cli(
         description="Get the allowed values for a ticket's custom fields"
     ).parse_args()
 

--- a/jira_commands/jira.py
+++ b/jira_commands/jira.py
@@ -107,7 +107,7 @@ def load_jira_settings(path: str, cli):
             if cli.pat_token:
                 settings["pat_token"] = cli.pat_token
             else:
-                logging.warning(f"cli pat token is None, skipping assignment")
+                logging.warning("cli pat token is None, skipping assignment")
         if "pat_token" not in settings:
             settings["pat_token"] = input("pat_token: ")
 
@@ -666,7 +666,7 @@ class JiraTool:
         username and password with curl against the JIRA API directly and that
         works, so I created an issue upstream.
 
-        I'm using this requests.get hack until https://github.com/pycontribs/jira/issues/1296
+        I'm using this requests.put hack until https://github.com/pycontribs/jira/issues/1296
         is fixed upstream.
 
         Based on https://confluence.atlassian.com/jirakb/how-to-use-rest-api-to-add-issue-links-in-jira-issues-939932271.html
@@ -722,7 +722,7 @@ class JiraTool:
         jira_auth = self.connection._session.auth
 
         logging.debug(f"Auth: {jira_auth}")
-        results = requests.put(url, auth=jira_auth, json=data)
+        results = requests.put(url, auth=jira_auth, json=data, timeout=30)
 
         logging.debug(f"status code: {results.status_code}")
 

--- a/jira_commands/jira.py
+++ b/jira_commands/jira.py
@@ -17,7 +17,9 @@ from thelogrus.yaml import readYamlFile
 
 
 def loadJiraSettings(path: str, cli):
-    logging.warning("loadJiraSettings() is deprecated and will be removed soon, use load_jira_settings()")
+    logging.warning(
+        "loadJiraSettings() is deprecated and will be removed soon, use load_jira_settings()"
+    )
     return load_jira_settings(path=path, cli=cli)
 
 
@@ -116,7 +118,9 @@ def load_jira_settings(path: str, cli):
 
 
 def makeIssueData(cli):
-    logging.warning("makeIssueData() is deprecated and will be removed soon, use make_issue_data()")
+    logging.warning(
+        "makeIssueData() is deprecated and will be removed soon, use make_issue_data()"
+    )
     return make_issue_data(cli=cli)
 
 
@@ -140,7 +144,7 @@ def make_issue_data(cli):
                 issue_data = json.loads(cli.json)
                 logging.debug(f"issue_data (from --json): {issue_data}")
             else:
-                logging.debug("json cli argument is None")
+                logging.debug("json cli argument is None, leaving it unset")
                 issue_data = {}
         else:
             logging.debug("Starting with blank issue data")
@@ -774,7 +778,9 @@ class JiraTool:
         return priority_data
 
     def getTicket(self, ticket: str):
-        logging.warning("JiraTool.getTicket() is deprecated and will be removed soon, use JiraTool.get_ticket()")
+        logging.warning(
+            "JiraTool.getTicket() is deprecated and will be removed soon, use JiraTool.get_ticket()"
+        )
         return self.get_ticket(ticket=ticket)
 
     def get_ticket(self, ticket: str):
@@ -818,7 +824,9 @@ class JiraTool:
         return tickets
 
     def transitionTicket(self, ticket: str, state: str, comment: str = None):
-        logging.warning("JiraTool.getTicket() is deprecated and will be removed soon, use JiraTool.get_ticket()")
+        logging.warning(
+            "JiraTool.getTicket() is deprecated and will be removed soon, use JiraTool.get_ticket()"
+        )
         return self.transition_ticket(ticket=ticket, state=state)
 
     def transition_ticket(self, ticket: str, state: str, comment: str = None):

--- a/jira_commands/jira.py
+++ b/jira_commands/jira.py
@@ -17,7 +17,7 @@ from thelogrus.yaml import readYamlFile
 
 
 def loadJiraSettings(path: str, cli):
-    logging.warning("loadJiraSettings() is deprecated, use load_jira_settings()")
+    logging.warning("loadJiraSettings() is deprecated and will be removed soon, use load_jira_settings()")
     return load_jira_settings(path=path, cli=cli)
 
 
@@ -116,7 +116,7 @@ def load_jira_settings(path: str, cli):
 
 
 def makeIssueData(cli):
-    logging.warning("makeIssueData() is deprecated, use make_issue_data()")
+    logging.warning("makeIssueData() is deprecated and will be removed soon, use make_issue_data()")
     return make_issue_data(cli=cli)
 
 
@@ -352,7 +352,7 @@ class JiraTool:
 
     def updateField(self, ticket: str, custom_field: str, value, field_type: str):
         logging.warning(
-            "JiraTool.updateField() is deprecated, use JiraTool.update_field"
+            "JiraTool.updateField() is deprecated and will be removed soon, use JiraTool.update_field"
         )
         return self.update_field(
             ticket=ticket, custom_field=custom_field, value=value, field_type=field_type
@@ -393,7 +393,7 @@ class JiraTool:
 
     def updateMultipleFields(self, ticket: str, fields: dict):
         logging.warning(
-            "JiraTool.updateField() is deprecated, use JiraTool.update_field"
+            "JiraTool.updateField() is deprecated and will be removed soon, use JiraTool.update_field"
         )
         return self.update_multiple_fields(ticket=ticket, fields=fields)
 
@@ -419,7 +419,7 @@ class JiraTool:
     # Utility functions
     def assignTicket(self, ticket: str, assignee: str):
         logging.warning(
-            "JiraTool.assignTicket() is deprecated, use JiraTool.assign_ticket"
+            "JiraTool.assignTicket() is deprecated and will be removed soon, use JiraTool.assign_ticket"
         )
         return self.assign_ticket(ticket=ticket, assignee=assignee)
 
@@ -439,7 +439,7 @@ class JiraTool:
 
     def unassignTicket(self, ticket: str):
         logging.warning(
-            "JiraTool.unassignTicket is deprecated, use JiraTool.unassign_ticket"
+            "JiraTool.unassignTicket is deprecated and will be removed soon, use JiraTool.unassign_ticket"
         )
         return self.unassign_ticket(ticket=ticket)
 
@@ -458,7 +458,7 @@ class JiraTool:
 
     def addComment(self, ticket: str, comment: str):
         logging.warning(
-            "JiraTool.unassignTicket is deprecated, use JiraTool.unassign_ticket"
+            "JiraTool.unassignTicket is deprecated and will be removed soon, use JiraTool.unassign_ticket"
         )
         return self.add_comment(ticket=ticket, comment=comment)
 
@@ -487,7 +487,7 @@ class JiraTool:
         required_fields: list = None,
     ):
         logging.warning(
-            "JiraTool.createTicket() is deprecated, use JiraTool.create_ticket"
+            "JiraTool.createTicket() is deprecated and will be removed soon, use JiraTool.create_ticket"
         )
         return self.create_ticket(
             issue_data=issue_data,
@@ -552,7 +552,7 @@ class JiraTool:
         strict: bool = True,
     ):
         logging.warning(
-            "JiraTool.createSubtask() is deprecated, use JiraTool.create_subtask"
+            "JiraTool.createSubtask() is deprecated and will be removed soon, use JiraTool.create_subtask"
         )
         return self.create_subtask(
             issue_data=issue_data,
@@ -596,7 +596,7 @@ class JiraTool:
 
     def getIssueData(self, ticket: str):
         logging.warning(
-            "JiraTool.getIssueData() is deprecated, use JiraTool.get_issue_data()"
+            "JiraTool.getIssueData() is deprecated and will be removed soon, use JiraTool.get_issue_data()"
         )
         return self.get_issue_data(ticket=ticket)
 
@@ -628,7 +628,7 @@ class JiraTool:
 
     def getIssueMetaData(self, ticket: str):
         logging.warning(
-            "JiraTool.getIssueMetaData() is deprecated, use JiraTool.get_issue_metadata()"
+            "JiraTool.getIssueMetaData() is deprecated and will be removed soon, use JiraTool.get_issue_metadata()"
         )
         return self.get_issue_metadata(ticket=ticket)
 
@@ -649,7 +649,7 @@ class JiraTool:
 
     def linkIssues(self, source: str, target: str, link_type: str):
         logging.warning(
-            "JiraTool.linkIssues() is deprecated, use JiraTool.link_issues()"
+            "JiraTool.linkIssues() is deprecated and will be removed soon, use JiraTool.link_issues()"
         )
         return self.link_issues(source=source, target=target, link_type=link_type)
 
@@ -734,7 +734,7 @@ class JiraTool:
 
     def listTickets(self, project: str):
         logging.warning(
-            "JiraTool.listTickets() is deprecated, use JiraTool.list_tickets()"
+            "JiraTool.listTickets() is deprecated and will be removed soon, use JiraTool.list_tickets()"
         )
         return self.list_tickets(project=project)
 
@@ -754,7 +754,7 @@ class JiraTool:
 
     def getPriorityDict(self):
         logging.warning(
-            "JiraTool.getPriorityDict() is deprecated, use JiraTool.get_priority_dict()"
+            "JiraTool.getPriorityDict() is deprecated and will be removed soon, use JiraTool.get_priority_dict()"
         )
         return self.get_priority_dict()
 
@@ -774,7 +774,7 @@ class JiraTool:
         return priority_data
 
     def getTicket(self, ticket: str):
-        logging.warning("JiraTool.getTicket() is deprecated, use JiraTool.get_ticket()")
+        logging.warning("JiraTool.getTicket() is deprecated and will be removed soon, use JiraTool.get_ticket()")
         return self.get_ticket(ticket=ticket)
 
     def get_ticket(self, ticket: str):
@@ -792,7 +792,7 @@ class JiraTool:
 
     def getTicketDict(self, project: str):
         logging.warning(
-            "JiraTool.getTicketDict() is deprecated, use JiraTool.get_ticket_dict()"
+            "JiraTool.getTicketDict() is deprecated and will be removed soon, use JiraTool.get_ticket_dict()"
         )
         return self.get_ticket_dict(project=project)
 
@@ -818,7 +818,7 @@ class JiraTool:
         return tickets
 
     def transitionTicket(self, ticket: str, state: str, comment: str = None):
-        logging.warning("JiraTool.getTicket() is deprecated, use JiraTool.get_ticket()")
+        logging.warning("JiraTool.getTicket() is deprecated and will be removed soon, use JiraTool.get_ticket()")
         return self.transition_ticket(ticket=ticket, state=state)
 
     def transition_ticket(self, ticket: str, state: str, comment: str = None):
@@ -963,7 +963,7 @@ class JiraTool:
 
     def ticketTransitions(self, ticket: str):
         logging.warning(
-            "JiraTool.ticketTransitions() is deprecated, use JiraTool.ticket_transitions()"
+            "JiraTool.ticketTransitions() is deprecated and will be removed soon, use JiraTool.ticket_transitions()"
         )
         return self.ticket_transitions(ticket=ticket)
 
@@ -1094,7 +1094,7 @@ class JiraTool:
         child_data=None,
     ):
         logging.warning(
-            "JiraTool.updateFieldDict() is deprecated, use JiraTool.update_field_dict()"
+            "JiraTool.updateFieldDict() is deprecated and will be removed soon, use JiraTool.update_field_dict()"
         )
         return self.update_field_dict(
             custom_field=custom_field,

--- a/jira_commands/jira.py
+++ b/jira_commands/jira.py
@@ -58,7 +58,7 @@ def load_jira_settings(path: str, cli):
         if "password" not in settings:
             settings["password"] = getpass.getpass("Password: ")
 
-    if cli.auth == "BASIC":
+        logging.debug("Using basic auth")
         if not settings["username"]:
             raise RuntimeError("You must specify the jira server username")
         if not settings["password"]:
@@ -75,6 +75,7 @@ def load_jira_settings(path: str, cli):
             logging.warning(f"There is already a credentials key in {path}")
 
     if cli.auth == "OAUTH":
+        logging.debug("Auth set to OAUTH")
         settings["oauth_access_token"] = cli.oauth_access_token
         settings["oauth_access_token_secret"] = cli.oauth_access_token_secret
         settings["oauth_consumer_key"] = cli.oauth_consumer_key
@@ -99,8 +100,12 @@ def load_jira_settings(path: str, cli):
             )
 
     if cli.auth == "PAT":
+        logging.debug("Auth set to PAT")
         if hasattr(cli, "pat_token"):
-            settings["pat_token"] = cli.pat_token
+            if cli.pat_token:
+                settings["pat_token"] = cli.pat_token
+            else:
+                logging.warning(f"cli pat token is None, skipping assignment")
         if "pat_token" not in settings:
             settings["pat_token"] = input("pat_token: ")
 
@@ -131,8 +136,12 @@ def make_issue_data(cli):
     """
     try:
         if hasattr(cli, "json"):
-            issue_data = json.loads(cli.json)
-            logging.debug(f"issue_data (from --json): {issue_data}")
+            if cli.json:
+                issue_data = json.loads(cli.json)
+                logging.debug(f"issue_data (from --json): {issue_data}")
+            else:
+                logging.debug("json cli argument is None")
+                issue_data = {}
         else:
             logging.debug("Starting with blank issue data")
             issue_data = {}
@@ -141,24 +150,31 @@ def make_issue_data(cli):
         raise missing_json
 
     if hasattr(cli, "description"):
-        logging.debug(f"description: {cli.description}")
-        issue_data["description"] = cli.description
+        if cli.description:
+            logging.debug(f"description: {cli.description}")
+            issue_data["description"] = cli.description
+        else:
+            issue_data["description"] = "No description set"
 
     if hasattr(cli, "issue_type"):
         logging.debug(f"issue_type: {cli.issue_type}")
         issue_data["issuetype"] = cli.issue_type
 
     if hasattr(cli, "label"):
-        logging.debug(f"label: {cli.label}")
-        issue_data["label"] = cli.label
+        if cli.label:
+            logging.debug(f"label: {cli.label}")
+            issue_data["label"] = cli.label
 
     if hasattr(cli, "project"):
         logging.debug(f"project: {cli.project}")
         issue_data["project"] = cli.project
 
     if hasattr(cli, "summary"):
-        logging.debug(f"summary: {cli.summary}")
-        issue_data["summary"] = cli.summary
+        if cli.summary:
+            logging.debug(f"summary: {cli.summary}")
+            issue_data["summary"] = cli.summary
+        else:
+            issue_data["summary"] = "No ticket summary set"
 
     return issue_data
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira-commands"
-version = "0.16.3"
+version = "0.16.4"
 description = "Command line utilities for interacting with JIRA"
 authors = ["Joe Block <jpb@unixorn.net>"]
 homepage = "https://github.com/unixorn/jira-commands"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira-commands"
-version = "0.16.4"
+version = "0.17.0"
 description = "Command line utilities for interacting with JIRA"
 authors = ["Joe Block <jpb@unixorn.net>"]
 homepage = "https://github.com/unixorn/jira-commands"


### PR DESCRIPTION
## Fix some cli argument handling bugs

Fix bad handling of unset cli arguments. When unset, `arpgarse` defaults them to `None`, passing them to JIRA makes it puke up errors.

Found this when the PAT from the settings file would be overwritten by the cli `--pat-token argument`, even if that was not specified -  `argparse` returns `None` when an argument is unset on the command line.

## Housekeeping

- Make parser function names more pythonic and add deprecation warnings for the old camelCase names
- Updated some deprecation warnings